### PR TITLE
chore: add BSD 2-Clause license and third-party attributions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+BSD 2-Clause License
+
+Copyright (c) 2026, N283T
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,68 @@
+NOTICE — Third-Party Acknowledgements
+
+zeasel is a Zig reimplementation of the Easel C library for biological
+sequence analysis. While no source code was copied, the algorithms,
+numerical constants, data tables, and API design are derived from Easel.
+
+================================================================================
+Easel
+================================================================================
+
+  Copyright (C) 1990-2023 Sean R. Eddy
+  Copyright (C) 2015-2023 President and Fellows of Harvard College
+  Copyright (C) 2000-2023 Howard Hughes Medical Institute
+  Copyright (C) 1995-2006 Washington University School of Medicine
+  Copyright (C) 1992-1995 MRC Laboratory of Molecular Biology, UK
+
+  Licensed under the BSD 2-Clause License.
+  https://github.com/EddyRivasLab/easel
+
+  Easel development is supported in part by the National Human Genome
+  Research Institute of the US National Institutes of Health under grant
+  number R01HG009116.
+
+The following elements are derived from Easel:
+
+  - Statistical distribution algorithms (Gumbel, GEV, gamma, exponential,
+    Weibull, normal, lognormal, Dirichlet)
+  - Conjugate gradient minimizer with Brent line search
+  - Incomplete gamma function (continued fraction and series)
+  - BLOSUM and PAM score matrix values
+  - WAG exchangeability parameters and equilibrium frequencies
+  - NCBI genetic code translation tables
+  - SSI (Sequence/Subsequence Index) binary format specification
+  - dsqdata binary packed sequence format specification
+  - Sequence weighting algorithms (PB, BLOSUM, GSC)
+  - Cobalt/Blue independent set algorithms (Petti & Eddy 2022)
+  - WUSS RNA secondary structure notation handling
+
+================================================================================
+Algorithms and constants from other sources (via Easel)
+================================================================================
+
+  Mersenne Twister RNG
+    Takuji Nishimura and Makoto Matsumoto
+    Copyright (C) 1997-2002
+    BSD License
+
+  SIMD vectorized logf/expf (Cephes polynomial approximations)
+    Stephen Moshier (original C)
+    Julien Pommier (SSE adaptation)
+    Public domain / zlib license
+
+  erfc() implementation
+    Sun Microsystems, Inc.
+    Copyright (C) 1993
+    Freely redistributable
+
+  Jenkins one-at-a-time hash
+    Bob Jenkins
+    Public domain
+
+  Gamma deviate (Marsaglia-Tsang method)
+    George Marsaglia and Wai Wan Tsang
+    "A Simple Method for Generating Gamma Variables" (2000)
+
+  Altschul-Erickson dinucleotide shuffle
+    Stephen F. Altschul and Bruce W. Erickson
+    "Significance of Nucleotide Sequence Alignments" (1985)

--- a/README.md
+++ b/README.md
@@ -232,4 +232,6 @@ Full comparison of Easel's C modules and their zeasel status.
 
 ## License
 
-See [LICENSE](LICENSE).
+BSD 2-Clause License. See [LICENSE](LICENSE).
+
+zeasel is a reimplementation of [Easel](https://github.com/EddyRivasLab/easel) (also BSD 2-Clause). Algorithms, constants, and format specifications are derived from Easel. See [NOTICE](NOTICE) for full attribution.


### PR DESCRIPTION
## Summary

- Add `LICENSE` (BSD 2-Clause, matching Easel)
- Add `NOTICE` with attributions to Easel and upstream algorithm sources (Mersenne Twister, Cephes, erfc, Jenkins hash, etc.)
- Update README license section